### PR TITLE
Skipping the hook shot backup and notification tables.

### DIFF
--- a/bin/ghe-backup
+++ b/bin/ghe-backup
@@ -151,9 +151,9 @@ echo "Backing up audit log ..."
 ghe-backup-es-audit-log ||
 failures="$failures audit-log"
 
-echo "Backing up hookshot logs ..."
-ghe-backup-es-hookshot ||
-failures="$failures hookshot"
+#echo "Backing up hookshot logs ..."
+#ghe-backup-es-hookshot ||
+#failures="$failures hookshot"
 
 echo "Backing up Git repositories ..."
 ghe-backup-repositories-${GHE_BACKUP_STRATEGY} ||

--- a/bin/ghe-backup
+++ b/bin/ghe-backup
@@ -78,7 +78,7 @@ fi
 
 echo "$GHE_SNAPSHOT_TIMESTAMP $$" > ../in-progress
 
-echo "Starting backup of $GHE_HOSTNAME in snapshot $GHE_SNAPSHOT_TIMESTAMP" | ts
+echo "Starting backup of $GHE_HOSTNAME in snapshot $GHE_SNAPSHOT_TIMESTAMP"
 
 # Perform a host connection check and establish the remote appliance version.
 # The version is available in the GHE_REMOTE_VERSION variable and also written
@@ -121,24 +121,24 @@ if [ "$GHE_BACKUP_STRATEGY" = "tarball" ]; then
     GHE_MAINTENANCE_MODE_ENABLED=true
 fi
 
-echo "Backing up GitHub settings ..." | ts
+echo "Backing up GitHub settings ..."
 ghe-backup-settings ||
 failures="$failures settings"
 
-echo "Backing up SSH authorized keys ..." | ts
+echo "Backing up SSH authorized keys ..."
 ghe-ssh "$GHE_HOSTNAME" -- 'ghe-export-authorized-keys' > authorized-keys.json ||
 failures="$failures authorized-keys"
 
-echo "Backing up SSH host keys ..." | ts
+echo "Backing up SSH host keys ..."
 ghe-ssh "$GHE_HOSTNAME" -- 'ghe-export-ssh-host-keys' > ssh-host-keys.tar ||
 failures="$failures ssh-host-keys"
 
-echo "Backing up MySQL database ..." | ts
+echo "Backing up MySQL database ..."
 echo 'set -o pipefail; ghe-export-mysql | gzip' |
 ghe-ssh "$GHE_HOSTNAME" -- /bin/bash > mysql.sql.gz ||
 failures="$failures mysql"
 
-echo "Backing up Redis database ..." | ts
+echo "Backing up Redis database ..."
 if $cluster; then
   ghe-backup-redis-cluster > redis.rdb ||
     failures="$failures redis"
@@ -147,7 +147,7 @@ else
     failures="$failures redis"
 fi
 
-echo "Backing up audit log ..." | ts
+echo "Backing up audit log ..."
 ghe-backup-es-audit-log ||
 failures="$failures audit-log"
 
@@ -155,11 +155,11 @@ failures="$failures audit-log"
 #ghe-backup-es-hookshot ||
 #failures="$failures hookshot"
 
-echo "Backing up Git repositories ..." | ts
+echo "Backing up Git repositories ..."
 ghe-backup-repositories-${GHE_BACKUP_STRATEGY} ||
 failures="$failures repositories"
 
-echo "Backing up GitHub Pages ..." | ts
+echo "Backing up GitHub Pages ..."
 ghe-backup-pages-${GHE_BACKUP_STRATEGY} ||
 failures="$failures pages"
 
@@ -184,7 +184,7 @@ if [ "$GHE_VERSION_MAJOR" -ge 2 ]; then
 fi
 
 if ! $cluster; then
-  echo "Backing up Elasticsearch indices ..." | ts
+  echo "Backing up Elasticsearch indices ..."
   ghe-backup-es-${GHE_BACKUP_STRATEGY} ||
   failures="$failures elasticsearch"
 fi
@@ -192,7 +192,6 @@ fi
 # If we're using the tarball backup strategy, bring the appliance out of
 # maintenance mode now instead of waiting until after pruning stale snapshots.
 if $GHE_MAINTENANCE_MODE_ENABLED; then
-    echo "Unsetting maintenance mode" | ts
     ghe-maintenance-mode-disable "$GHE_HOSTNAME" ||
         echo "Warning: Disabling maintenance mode on $GHE_HOSTNAME failed."
     GHE_MAINTENANCE_MODE_ENABLED=false
@@ -210,7 +209,7 @@ if [ -z "$failures" ]; then
     ghe-prune-snapshots
 fi
 
-echo "Completed backup of $GHE_HOSTNAME in snapshot $GHE_SNAPSHOT_TIMESTAMP at $(date +"%H:%M:%S")" | ts
+echo "Completed backup of $GHE_HOSTNAME in snapshot $GHE_SNAPSHOT_TIMESTAMP at $(date +"%H:%M:%S")"
 
 # Exit non-zero and list the steps that failed.
 if [ -z "$failures" ]; then

--- a/bin/ghe-backup
+++ b/bin/ghe-backup
@@ -78,7 +78,7 @@ fi
 
 echo "$GHE_SNAPSHOT_TIMESTAMP $$" > ../in-progress
 
-echo "Starting backup of $GHE_HOSTNAME in snapshot $GHE_SNAPSHOT_TIMESTAMP"
+echo "Starting backup of $GHE_HOSTNAME in snapshot $GHE_SNAPSHOT_TIMESTAMP" | ts
 
 # Perform a host connection check and establish the remote appliance version.
 # The version is available in the GHE_REMOTE_VERSION variable and also written
@@ -121,24 +121,24 @@ if [ "$GHE_BACKUP_STRATEGY" = "tarball" ]; then
     GHE_MAINTENANCE_MODE_ENABLED=true
 fi
 
-echo "Backing up GitHub settings ..."
+echo "Backing up GitHub settings ..." | ts
 ghe-backup-settings ||
 failures="$failures settings"
 
-echo "Backing up SSH authorized keys ..."
+echo "Backing up SSH authorized keys ..." | ts
 ghe-ssh "$GHE_HOSTNAME" -- 'ghe-export-authorized-keys' > authorized-keys.json ||
 failures="$failures authorized-keys"
 
-echo "Backing up SSH host keys ..."
+echo "Backing up SSH host keys ..." | ts
 ghe-ssh "$GHE_HOSTNAME" -- 'ghe-export-ssh-host-keys' > ssh-host-keys.tar ||
 failures="$failures ssh-host-keys"
 
-echo "Backing up MySQL database ..."
+echo "Backing up MySQL database ..." | ts
 echo 'set -o pipefail; ghe-export-mysql | gzip' |
 ghe-ssh "$GHE_HOSTNAME" -- /bin/bash > mysql.sql.gz ||
 failures="$failures mysql"
 
-echo "Backing up Redis database ..."
+echo "Backing up Redis database ..." | ts
 if $cluster; then
   ghe-backup-redis-cluster > redis.rdb ||
     failures="$failures redis"
@@ -147,7 +147,7 @@ else
     failures="$failures redis"
 fi
 
-echo "Backing up audit log ..."
+echo "Backing up audit log ..." | ts
 ghe-backup-es-audit-log ||
 failures="$failures audit-log"
 
@@ -155,11 +155,11 @@ failures="$failures audit-log"
 #ghe-backup-es-hookshot ||
 #failures="$failures hookshot"
 
-echo "Backing up Git repositories ..."
+echo "Backing up Git repositories ..." | ts
 ghe-backup-repositories-${GHE_BACKUP_STRATEGY} ||
 failures="$failures repositories"
 
-echo "Backing up GitHub Pages ..."
+echo "Backing up GitHub Pages ..." | ts
 ghe-backup-pages-${GHE_BACKUP_STRATEGY} ||
 failures="$failures pages"
 
@@ -184,7 +184,7 @@ if [ "$GHE_VERSION_MAJOR" -ge 2 ]; then
 fi
 
 if ! $cluster; then
-  echo "Backing up Elasticsearch indices ..."
+  echo "Backing up Elasticsearch indices ..." | ts
   ghe-backup-es-${GHE_BACKUP_STRATEGY} ||
   failures="$failures elasticsearch"
 fi
@@ -192,6 +192,7 @@ fi
 # If we're using the tarball backup strategy, bring the appliance out of
 # maintenance mode now instead of waiting until after pruning stale snapshots.
 if $GHE_MAINTENANCE_MODE_ENABLED; then
+    echo "Unsetting maintenance mode" | ts
     ghe-maintenance-mode-disable "$GHE_HOSTNAME" ||
         echo "Warning: Disabling maintenance mode on $GHE_HOSTNAME failed."
     GHE_MAINTENANCE_MODE_ENABLED=false
@@ -209,7 +210,7 @@ if [ -z "$failures" ]; then
     ghe-prune-snapshots
 fi
 
-echo "Completed backup of $GHE_HOSTNAME in snapshot $GHE_SNAPSHOT_TIMESTAMP at $(date +"%H:%M:%S")"
+echo "Completed backup of $GHE_HOSTNAME in snapshot $GHE_SNAPSHOT_TIMESTAMP at $(date +"%H:%M:%S")" | ts
 
 # Exit non-zero and list the steps that failed.
 if [ -z "$failures" ]; then

--- a/bin/ghe-restore
+++ b/bin/ghe-restore
@@ -234,8 +234,8 @@ elif [ "$GHE_VERSION_MAJOR" -ge 2 ]; then
   echo "Restoring storage data ..."
   ghe-restore-userdata storage "$GHE_HOSTNAME" 1>&3
 
-  echo "Restoring hook deliveries ..."
-  ghe-restore-userdata hookshot "$GHE_HOSTNAME" 1>&3
+#  echo "Restoring hook deliveries ..."
+#  ghe-restore-userdata hookshot "$GHE_HOSTNAME" 1>&3
 fi
 
 if $cluster; then

--- a/enterprise-scripts/ghe-export-mysql
+++ b/enterprise-scripts/ghe-export-mysql
@@ -1,0 +1,24 @@
+#!/bin/sh
+#/ Usage: ghe-export-mysql | ssh admin@enterprise -- ghe-import-mysql
+set -e
+
+# Show usage.
+if [ "$1" = "--help" ]
+then grep '^#/' <"$0" |cut -c 4-
+    exit 2
+fi
+
+[ "`whoami`" = "git" ] || {
+    exec sudo -u git "$0" "$@"
+    echo Run this script as the git user. >&2
+    exit 1
+}
+
+mysqldump \
+  -u root \
+  --hex-blob \
+  --single-transaction \
+  --quick \
+  --ignore-table github_enterprise.notification_deliveries
+  --ignore-table github_enterprise.notification_entries
+  github_enterprise

--- a/enterprise-scripts/ghe-export-mysql
+++ b/enterprise-scripts/ghe-export-mysql
@@ -21,7 +21,7 @@ mysqldump \
   --quick \
   --ignore-table github_enterprise.notification_deliveries \
   --ignore-table github_enterprise.notification_entries \
-  github_enterprise; \
+  github_enterprise 
 
 mysqldump \
    -u root \
@@ -30,7 +30,7 @@ mysqldump \
    --quick \
    --no-create-db \ 
    --where="1 and notification_deliveries.delivered_at BETWEEN NOW() - INTERVAL 30 DAY AND NOW()" \
-   github_enterprise notification_deliveries; \
+   github_enterprise notification_deliveries
 
 mysqldump \
     -u root \ 

--- a/enterprise-scripts/ghe-export-mysql
+++ b/enterprise-scripts/ghe-export-mysql
@@ -19,6 +19,24 @@ mysqldump \
   --hex-blob \
   --single-transaction \
   --quick \
-  --ignore-table github_enterprise.notification_deliveries
-  --ignore-table github_enterprise.notification_entries
-  github_enterprise
+  --ignore-table github_enterprise.notification_deliveries \
+  --ignore-table github_enterprise.notification_entries \
+  github_enterprise; \
+
+mysqldump \
+   -u root \
+   --hex-blob \ 
+   --single-transaction \
+   --quick \
+   --no-create-db \ 
+   --where="1 and notification_deliveries.delivered_at BETWEEN NOW() - INTERVAL 30 DAY AND NOW()" \
+   github_enterprise notification_deliveries; \
+
+mysqldump \
+    -u root \ 
+    --hex-blob \ 
+    --single-transaction \ 
+    --quick \
+    --no-create-db \
+    --where="1 and notification_entries.updated_at BETWEEN NOW() - INTERVAL 30 DAY AND NOW()" \
+    github_enterprise notification_entries


### PR DESCRIPTION
- Skipping "hook shot" backup in `bin/backup`
- Skipping 'notification_deliveries' and 'notification_entries' in `enterprise-scripts/ghe-export-mysql`
